### PR TITLE
Various improvements per discussion in #taskwarrior

### DIFF
--- a/twan.sh
+++ b/twan.sh
@@ -12,7 +12,8 @@ if [[ "$ID" != [0-9]* ]]; then
     exit 1
 fi
 FILE="`mktemp`"
-vi "$FILE"
+EDITOR="${EDITOR:-vi}"
+$EDITOR "$FILE"
 task $ID annotate "`cat $FILE`"
 rm "$FILE"
 exit 0

--- a/twan.sh
+++ b/twan.sh
@@ -11,8 +11,9 @@ if [[ "$ID" != [0-9]* ]]; then
     echo "  ERROR: twan command must be followed by a single task ID"
     exit 1
 fi
-vi /tmp/tw-annot-$ID.tmp
-task $ID annotate "`cat /tmp/tw-annot-$ID.tmp`"
-rm /tmp/tw-annot-$ID.tmp
+FILE="`mktemp`"
+vi "$FILE"
+task $ID annotate "`cat $FILE`"
+rm "$FILE"
 exit 0
 

--- a/twan.sh
+++ b/twan.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 #
 # twan.sh
 # Copyright (C) 2016 djp <djp@cutter>
@@ -7,7 +7,7 @@
 #
 
 ID=$*
-if [[ "$ID" != [0-9]* ]]; then 
+if ! echo "$ID" | grep -q '[0-9]\+'; then
     echo "  ERROR: twan command must be followed by a single task ID"
     exit 1
 fi


### PR DESCRIPTION
Here's three changes I thought you may be interested in per a discussion in #taskwarrior:
- Use a unique temporary file, to avoid conflicts in case someone else is also annotating the a task with the same id at the same time.
- Use $EDITOR, so people will get their prefered editor by default, instead of vim
- Avoid bash-isms for portability, so this works on POSIX platforms which do not have bash.
